### PR TITLE
Update array APIs for filtering by unique id and storage type

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -761,6 +761,20 @@ var doc = `{
                 ],
                 "summary": "List all storage arrays",
                 "operationId": "list-storage-arrays",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Unique ID",
+                        "name": "unique_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Storage Type",
+                        "name": "storage_type",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "202": {
                         "description": "Accepted",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -745,6 +745,20 @@
                 ],
                 "summary": "List all storage arrays",
                 "operationId": "list-storage-arrays",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Unique ID",
+                        "name": "unique_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Storage Type",
+                        "name": "storage_type",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "202": {
                         "description": "Accepted",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -699,6 +699,15 @@ paths:
       - application/json
       description: List all storage arrays
       operationId: list-storage-arrays
+      parameters:
+      - description: Unique ID
+        in: query
+        name: unique_id
+        type: string
+      - description: Storage Type
+        in: query
+        name: storage_type
+        type: string
       produces:
       - application/json
       responses:

--- a/handler/storage_array.go
+++ b/handler/storage_array.go
@@ -83,6 +83,8 @@ func (h *StorageArrayHandler) UpdateStorageArray(c echo.Context) error {
 // @Tags storage-array
 // @Accept  json
 // @Produce  json
+// @Param unique_id query string false "Unique ID"
+// @Param storage_type query string false "Storage Type"
 // @Success 202 {object} []storageArrayResponse
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
@@ -90,7 +92,17 @@ func (h *StorageArrayHandler) UpdateStorageArray(c echo.Context) error {
 // @Security ApiKeyAuth
 // @Router /storage-arrays [get]
 func (h *StorageArrayHandler) ListStorageArrays(c echo.Context) error {
-	arrays, err := h.arrayStore.GetAll()
+	uniqueID := c.QueryParam("unique_id")
+	storageTypeName := c.QueryParam("storage_type")
+	var arrays []model.StorageArray
+	var err error
+	if uniqueID != "" {
+		arrays, err = h.arrayStore.GetAllByUniqueID(uniqueID)
+	} else if storageTypeName != "" {
+		arrays, err = h.arrayStore.GetAllByStorageType(storageTypeName)
+	} else {
+		arrays, err = h.arrayStore.GetAll()
+	}
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, utils.NewErrorResponse(http.StatusInternalServerError, utils.CriticalSeverity, "", err))
 	}

--- a/store/mocks/storage_array_store_interface.go
+++ b/store/mocks/storage_array_store_interface.go
@@ -95,6 +95,36 @@ func (mr *MockStorageArrayStoreInterfaceMockRecorder) GetAllByID(arg0 ...interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllByID", reflect.TypeOf((*MockStorageArrayStoreInterface)(nil).GetAllByID), arg0...)
 }
 
+// GetAllByStorageType mocks base method
+func (m *MockStorageArrayStoreInterface) GetAllByStorageType(arg0 string) ([]model.StorageArray, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllByStorageType", arg0)
+	ret0, _ := ret[0].([]model.StorageArray)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllByStorageType indicates an expected call of GetAllByStorageType
+func (mr *MockStorageArrayStoreInterfaceMockRecorder) GetAllByStorageType(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllByStorageType", reflect.TypeOf((*MockStorageArrayStoreInterface)(nil).GetAllByStorageType), arg0)
+}
+
+// GetAllByUniqueID mocks base method
+func (m *MockStorageArrayStoreInterface) GetAllByUniqueID(arg0 string) ([]model.StorageArray, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllByUniqueID", arg0)
+	ret0, _ := ret[0].([]model.StorageArray)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllByUniqueID indicates an expected call of GetAllByUniqueID
+func (mr *MockStorageArrayStoreInterfaceMockRecorder) GetAllByUniqueID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllByUniqueID", reflect.TypeOf((*MockStorageArrayStoreInterface)(nil).GetAllByUniqueID), arg0)
+}
+
 // GetByID mocks base method
 func (m *MockStorageArrayStoreInterface) GetByID(arg0 uint) (*model.StorageArray, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
#### Submission Checklist

#### Common
* [x] Have you run vet & lint checks against your submission?
* [x] Have you made sure that the code compiles?
* [x] Did you run the unit & integration tests successfully?
* [x] Did you run tests in a real Kubernetes cluster?
* [x] Did you verify if you are _not_ checking in any local image references? For e.g. -in a Makefile, env.sh

#### Swagger
* [x] Have you made any changes to the APIs?
* [x] Have you verified the newly added API is working properly from the swagger?
* [x] Have you checked whether the existing APIs are not broken?
* [x] Have you verified if the docker image builds successfully?

### Description of your changes
Updates the ListStorageArrays API call with 2 filtering options for unique_id and storage_type:
Ex: ```GET /v1/api/storage-arrays?unique_id=<unique-identifier>```
Ex: ```GET /v1/api/storage-arrays?storage_type=powerflex``` (accepts any valid storage type)

