### PR TITLE
Fix NFS precheck for SLES hosts

### DIFF
--- a/datacollectorapp/run.sh
+++ b/datacollectorapp/run.sh
@@ -4,6 +4,6 @@ fi
 if [ -f /hostproc/modules ]; then
   echo "sdc=`grep "scini" /hostproc/modules | awk -F  " " '{print $2}'`"
 fi
-if [ -f /hostusr/local/sbin/mount.nfs ] || [ -f /hostusr/local/bin/mount.nfs ] || [ -f /hostusr/sbin/mount.nfs ] || [ -f /hostusr/bin/mount.nfs ]; then
+if [ -f /hostusr/local/sbin/mount.nfs ] || [ -f /hostusr/local/bin/mount.nfs ] || [ -f /hostusr/sbin/mount.nfs ] || [ -f /hostusr/bin/mount.nfs ] || [ -f /hostusr/sbin/rpc.nfsd ]; then
   echo "nfs=true"
 fi


### PR DESCRIPTION
#### Submission Checklist

#### Common
* [x] Have you run vet & lint checks against your submission?
* [x] Have you made sure that the code compiles?
* [x] Did you run the unit & integration tests successfully?
* [x] Did you run tests in a real Kubernetes cluster?
* [x] Did you verify if you are _not_ checking in any local image references? For e.g. -in a Makefile, env.sh

#### Swagger
* [ ] Have you made any changes to the APIs?
* [ ] Have you verified the newly added API is working properly from the swagger?
* [ ] Have you checked whether the existing APIs are not broken?
* [ ] Have you verified if the docker image builds successfully?

### Description of your changes
Fixes precheck for NFS on SLES hosts by checking if the file `/usr/sbin/rpc.nfsd` is available on the host.
