### PR TITLE
Removed unnecessary headers from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,20 @@ Copyright (c) 2021 Dell Inc., or its subsidiaries. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
+   
     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 
 # Dell Container Storage Modules (CSM)
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](docs/CODE_OF_CONDUCT.md)
 [![License](https://img.shields.io/github/license/dell/csm)](LICENSE)
-[![Docker Pulls](https://img.shields.io/docker/pulls/dellemc/dell-csm-installer)](https://hub.docker.com/r/dellemc/dell-csm-installer)
-[![Go version](https://img.shields.io/github/go-mod/go-version/dell/csm)](go.mod)
 [![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/dell/csm?include_prereleases&label=latest&style=flat-square)](https://github.com/dell/csm/releases/latest)
 
 Dell Container Storage Modules (CSM) is an open-source suite of Kubernetes storage enablers for Dell products.


### PR DESCRIPTION
# Description
Removed the Docker Pulls and Go Version headers from the README file.  These are no longer needed since the repository is tied directly to any Docker image or Go code.  Also updated copyright notice in the README.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| N/A |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Visual inspection to verify headers are removed.
