### PR TITLE
Add dell-csi-operator deprecation notice in changelog

### DIFF
--- a/CHANGELOG/CHANGELOG-1.8.0.md
+++ b/CHANGELOG/CHANGELOG-1.8.0.md
@@ -32,6 +32,7 @@ The workaround for this issue is to disable root squashing by setting allowRoot:
 
 ### Deprecation 
 
+- The Dell CSI Operator is no longer actively maintained or supported. It will be deprecated in CSM 1.9. It is highly recommended that you use [CSM Operator](https://dell.github.io/csm-docs/docs/deployment/csmoperator/) going forward.
 ### Features 
 
 - K8S 1.28 support in CSM 1.8. ([#947](https://github.com/dell/csm/issues/947))


### PR DESCRIPTION
<!--
Copyright (c) 2021 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at
   
    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
# Description
Add dell-csi-operator deprecation notice to changelog-1.8

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility


