### PR TITLE
UBI image update

### DIFF
--- a/config/csm-common.mk
+++ b/config/csm-common.mk
@@ -14,7 +14,7 @@
 # Update this file with the image versions change, and it will be automaticall rolled out across all components.
 
 # --- DEFAULT_BASEIMAGE: Specifies the UBI-micro image that is used as the base for the CSM images
-DEFAULT_BASEIMAGE="registry.redhat.io/ubi9/ubi-micro@sha256:11b5e26e24ce14b02372860115162e81ae011b748619b371f261e1e97d4cf2bf"
+DEFAULT_BASEIMAGE="registry.access.redhat.com/ubi9/ubi-micro@sha256:7f376b75faf8ea546f28f8529c37d24adcde33dca4103f4897ae19a43d58192b"
 
 # --- DEFAULT_GOVERSION: Specifies the default version of go
 DEFAULT_GOVERSION="1.23"

--- a/config/csm-common.mk
+++ b/config/csm-common.mk
@@ -14,7 +14,7 @@
 # Update this file with the image versions change, and it will be automaticall rolled out across all components.
 
 # --- DEFAULT_BASEIMAGE: Specifies the UBI-micro image that is used as the base for the CSM images
-DEFAULT_BASEIMAGE="registry.access.redhat.com/ubi9/ubi-micro@sha256:9dbba858e5c8821fbe1a36c376ba23b83ba00f100126f2073baa32df2c8e183a"
+DEFAULT_BASEIMAGE="registry.redhat.io/ubi9/ubi-micro@sha256:11b5e26e24ce14b02372860115162e81ae011b748619b371f261e1e97d4cf2bf"
 
 # --- DEFAULT_GOVERSION: Specifies the default version of go
 DEFAULT_GOVERSION="1.23"


### PR DESCRIPTION
<!--
Copyright (c) 2021 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at
   
    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
# Description
Updating UBI Image to ubi9/ubi-micro 9.4-15

