### PR TITLE
Use a common CSM base image to avoid rebuilding the base image during builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clean:
 docker:
 	$(eval include config/csm-common.mk)
 	$(eval include semver.mk)
-	@echo "Building base image from $(DEFAULT_BASEIMAGE) and loading dependencies..."
-	cd base-image && ./build-base-image.sh -u $(DEFAULT_BASEIMAGE) -t $(REGISTRY)/$(IMAGENAME):$(IMAGETAG) $(BASE_IMAGE_PACKAGES)
-	$(eval BASEIMAGE=$(REGISTRY)/$(IMAGENAME):$(IMAGETAG))
-	@echo "Built base image: $(BASEIMAGE)"
+	@echo "Building base image from $(UBI_BASEIMAGE) and loading dependencies..."
+	cd base-image && ./build-base-image.sh -u $(UBI_BASEIMAGE) -t $(CSMBASEIMAGE_IMAGE):$(IMAGETAG) $(BASE_IMAGE_PACKAGES)
+	$(eval BASEIMAGE=$(CSMBASEIMAGE_IMAGE):$(IMAGETAG))
+	@echo "Built base image: $(CSMBASEIMAGE_IMAGE):$(IMAGETAG)"

--- a/base-image/build-base-image.sh
+++ b/base-image/build-base-image.sh
@@ -65,7 +65,7 @@ function build() {
 
 # check to see if the host is RedHat Enterprise Linux as it is required
 if [ ! -f /etc/redhat-release ]; then
-  echo "This does not appear to eb a RedHat Enterprise Linux system"
+  echo "This does not appear to be a RedHat Enterprise Linux system"
   echo "No file at /etc/redhat-release was found"
   exit 1
 fi

--- a/config/csm-common.mk
+++ b/config/csm-common.mk
@@ -10,14 +10,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Common settings for all CSM components amd images.
-# Update this file with the image versions change, and it will be automaticall rolled out across all components.
+# This file is intended to be included from within a Makefile,
+# so is restricted to Makefile syntax
 
-# --- CSMBASEIMAGE settings: Define the values for a common UBI-micro based image 
+# Common settings for all CSM components and images.
+# Update this file when the image versions change, and it will be automatically rolled out across all components.
+
+# --- CSMBASEIMAGE settings: Define the values for a common UBI-micro based image
+# registry
 CSMBASEIMAGE_REGISTRY="docker.io"
+# organization
 CSMBASEIMAGE_NAMESPACE="dellemc"
+# iamge
 CSMBASEIMAGE_NAME="csm-base-image"
+# finds the highest semanticly versioned tag
 CSMBASEIMAGE_TAG_NEWEST=$(curl -s "https://hub.docker.com/v2/namespaces/${CSMBASEIMAGE_NAMESPACE}/repositories/${CSMBASEIMAGE_NAME}/tags?page_size=1000" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -E '^([0-9]|v[0-9])' | sort -V | tail -n 1)
+# full image name, without tag
 CSMBASEIMAGE_IMAGE="${CSMBASEIMAGE_REGISTRY}/${CSMBASEIMAGE_NAMESPACE}/${CSMBASEIMAGE_NAME}"
 
 # set the CSMBASEIMAGE_TAG_NEWEST if no semanticly versioned tags were found
@@ -25,7 +33,7 @@ ifeq ($(CSMBASEIMAGE_TAG_NEWEST),)
 export CSMBASEIMAGE_TAG_NEWEST="nightly"
 endif
 
-# UBI_BASEIMAGE settings: Define values for the UBI-micro image to be used as a base
+# --- UBI_BASEIMAGE: Value of the UBI-micro image to be used as a base
 UBI_BASEIMAGE="registry.access.redhat.com/ubi9/ubi-micro@sha256:9dbba858e5c8821fbe1a36c376ba23b83ba00f100126f2073baa32df2c8e183a"
 
 # --- DEFAULT_BASEIMAGE: Specifies the UBI-micro image that is used as the base for the CSM images

--- a/config/csm-common.mk
+++ b/config/csm-common.mk
@@ -1,4 +1,4 @@
-# Copyright © 2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2024-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,31 +16,35 @@
 # Common settings for all CSM components and images.
 # Update this file when the image versions change, and it will be automatically rolled out across all components.
 
-# --- CSMBASEIMAGE settings: Define the values for a common UBI-micro based image
-# registry
-CSMBASEIMAGE_REGISTRY="docker.io"
-# organization
-CSMBASEIMAGE_NAMESPACE="dellemc"
-# iamge
-CSMBASEIMAGE_NAME="csm-base-image"
-# finds the highest semantically versioned tag
-CSMBASEIMAGE_TAG_NEWEST=$(curl -s "https://hub.docker.com/v2/namespaces/${CSMBASEIMAGE_NAMESPACE}/repositories/${CSMBASEIMAGE_NAME}/tags?page_size=1000" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -E '^([0-9]|v[0-9])' | sort -V | tail -n 1)
-# full image name, without tag
-CSMBASEIMAGE_IMAGE="${CSMBASEIMAGE_REGISTRY}/${CSMBASEIMAGE_NAMESPACE}/${CSMBASEIMAGE_NAME}"
+# --- UBI_BASEIMAGE: Value of the UBI image to be used as a base for all images.
+UBI_BASEIMAGE=registry.access.redhat.com/ubi9/ubi-micro@sha256:7f376b75faf8ea546f28f8529c37d24adcde33dca4103f4897ae19a43d58192b
 
-# set the CSMBASEIMAGE_TAG_NEWEST if no semantically versioned tags were found
+# --- CSMBASEIMAGE settings: Define the values for a common UBI-micro based image.
+# registry
+CSMBASEIMAGE_REGISTRY=quay.io
+# organization
+CSMBASEIMAGE_NAMESPACE=dell/container-storage-modules
+# image
+CSMBASEIMAGE_NAME=csm-base-image
+# tag
+CSMBASEIMAGE_TAG_NEWEST=nightly
+# full image name, without tag
+CSMBASEIMAGE_IMAGE=${CSMBASEIMAGE_REGISTRY}/${CSMBASEIMAGE_NAMESPACE}/${CSMBASEIMAGE_NAME}
+
+# Set the CSMBASEIMAGE_TAG_NEWEST if no semantically versioned tags were found.
 ifeq ($(CSMBASEIMAGE_TAG_NEWEST),)
-export CSMBASEIMAGE_TAG_NEWEST="nightly"
+export CSMBASEIMAGE_TAG_NEWEST=nightly
 endif
 
-# --- UBI_BASEIMAGE: Value of the UBI-micro image to be used as a base
-UBI_BASEIMAGE="registry.access.redhat.com/ubi9/ubi-micro@sha256:9dbba858e5c8821fbe1a36c376ba23b83ba00f100126f2073baa32df2c8e183a"
+# --- CSM_BASEIMAGE: Specifies the common baseimage that is used for all CSM images.
+CSM_BASEIMAGE=${CSMBASEIMAGE_IMAGE}:${CSMBASEIMAGE_TAG_NEWEST}
 
-# --- DEFAULT_BASEIMAGE: Specifies the UBI-micro image that is used as the base for the CSM images
-DEFAULT_BASEIMAGE="${CSMBASEIMAGE_IMAGE}:${CSMBASEIMAGE_TAG_NEWEST}"
+# --- DEFAULT_BASEIMAGE: Specifies the default image for repositories not yet using the CSM_BASEIMAGE.
+# --- Repositories should switch to using the CSM_BASEIMAGE to use the new common base image.
+DEFAULT_BASEIMAGE=${UBI_BASEIMAGE}
 
-# --- DEFAULT_GOVERSION: Specifies the default version of go
-DEFAULT_GOVERSION="1.23"
+# --- DEFAULT_GOVERSION: Specifies the default version of go.
+DEFAULT_GOVERSION=1.23
 
-# --- DEFAULT_GOIMAGE: Specifies the default Image to be used for building go components in a multi-stage docker file
-DEFAULT_GOIMAGE="golang:${DEFAULT_GOVERSION}"
+# --- DEFAULT_GOIMAGE: Specifies the default Image to be used for building go components in a multi-stage docker file.
+DEFAULT_GOIMAGE=golang:${DEFAULT_GOVERSION}

--- a/config/csm-common.mk
+++ b/config/csm-common.mk
@@ -13,8 +13,23 @@
 # Common settings for all CSM components amd images.
 # Update this file with the image versions change, and it will be automaticall rolled out across all components.
 
+# --- CSMBASEIMAGE settings: Define the values for a common UBI-micro based image 
+CSMBASEIMAGE_REGISTRY="docker.io"
+CSMBASEIMAGE_NAMESPACE="dellemc"
+CSMBASEIMAGE_NAME="csm-base-image"
+CSMBASEIMAGE_TAG_NEWEST=$(curl -s "https://hub.docker.com/v2/namespaces/${CSMBASEIMAGE_NAMESPACE}/repositories/${CSMBASEIMAGE_NAME}/tags?page_size=1000" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -E '^([0-9]|v[0-9])' | sort -V | tail -n 1)
+CSMBASEIMAGE_IMAGE="${CSMBASEIMAGE_REGISTRY}/${CSMBASEIMAGE_NAMESPACE}/${CSMBASEIMAGE_NAME}"
+
+# set the CSMBASEIMAGE_TAG_NEWEST if no semanticly versioned tags were found
+ifeq ($(CSMBASEIMAGE_TAG_NEWEST),)
+export CSMBASEIMAGE_TAG_NEWEST="nightly"
+endif
+
+# UBI_BASEIMAGE settings: Define values for the UBI-micro image to be used as a base
+UBI_BASEIMAGE="registry.access.redhat.com/ubi9/ubi-micro@sha256:9dbba858e5c8821fbe1a36c376ba23b83ba00f100126f2073baa32df2c8e183a"
+
 # --- DEFAULT_BASEIMAGE: Specifies the UBI-micro image that is used as the base for the CSM images
-DEFAULT_BASEIMAGE="registry.access.redhat.com/ubi9/ubi-micro@sha256:9dbba858e5c8821fbe1a36c376ba23b83ba00f100126f2073baa32df2c8e183a"
+DEFAULT_BASEIMAGE="${CSMBASEIMAGE_IMAGE}:${CSMBASEIMAGE_TAG_NEWEST}"
 
 # --- DEFAULT_GOVERSION: Specifies the default version of go
 DEFAULT_GOVERSION="1.23"


### PR DESCRIPTION
# Description
In order to avoid repeated builds of the base image that the repositories are currently using we will make use of the nightly csm-base-image. This will save time during the pipeline builds and also during developer iterations. This will also facilitate building on non RHEL systems as buildah and the host's RPM database will not be a requirement.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1691 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Tested with Operator image build, see [PR 688](https://github.com/dell/csm-operator/pull/688)
- [X] Built a driver image with the new csm-common.mk to validate that existing repositories build.
- [X] Built the csm-base-image to validate that the UBI image is used.
