### PR TITLE
Fix base image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,5 @@ docker:
 	$(eval include config/csm-common.mk)
 	$(eval include semver.mk)
 	@echo "Building base image from $(UBI_BASEIMAGE) and loading dependencies..."
-	cd base-image && ./build-base-image.sh -u $(UBI_BASEIMAGE) -t $(CSMBASEIMAGE_IMAGE):$(IMAGETAG) $(BASE_IMAGE_PACKAGES)
-	$(eval BASEIMAGE=$(CSMBASEIMAGE_IMAGE):$(IMAGETAG))
-	@echo "Built base image: $(CSMBASEIMAGE_IMAGE):$(IMAGETAG)"
+	cd base-image && ./build-base-image.sh -u $(UBI_BASEIMAGE) -t $(REGISTRY)/$(IMAGENAME):$(IMAGETAG) $(BASE_IMAGE_PACKAGES)
+	@echo "Built base image: $(REGISTRY)/$(IMAGENAME):$(IMAGETAG)"


### PR DESCRIPTION
Base image build failing from Makefile due to references to variables that were cleaned up. The Makefile should have been using the variables from the overrides.mk. Made the change and validated that the image name and tag will match what the pipeline expects.

```
REPOSITORY                                 TAG         IMAGE ID      CREATED        SIZE
localhost/sample_registry/csm-base-image   nightly     9a1d45b03c8d  9 minutes ago  209 MB

```


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1707 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X ] Built base image with changes on RHEL VM as root. Ran make docker with IMAGETAG set as the pipeline does.

