### PR TITLE
Add bzip2 for app-mobility dependency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ BASE_IMAGE_PACKAGES=acl \
 					e2fsprogs \
 					gnutls \
 					gzip \
+					bzip2 \
 					hostname \
 					kmod \
 					libaio \


### PR DESCRIPTION
# Description
Add bzip2 to common base image. Currently used in app-mobility image and neither yum nor dnf is on the base image. Putting this in the base image will not significantly add to the image size.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1691|

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Built app-mobility image and validated that a container using the image can start up.

