### PR TITLE
Automation: Fix csm-version value for otel-collector

### DIFF
--- a/.github/scripts/update-versions.sh
+++ b/.github/scripts/update-versions.sh
@@ -26,6 +26,12 @@ update_versions() {
 
         if grep -q $key $version_file; then
             current_version=$(grep $key $version_file | cut -d ":" -f 2 | tr -d ' ')
+
+            # Sanitize otel-collector version. Tag is different format than artifactory.
+            if [ "$key" == "otel-collector" ]; then
+                latest_tag=$(echo "$latest_tag" | sed 's/^v//')
+            fi
+
             if [ "$current_version" == "$latest_tag" ]; then
                 echo "$key already up to date"
                 continue


### PR DESCRIPTION
<!--
Copyright (c) 2021 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at
   
    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
# Description
Fix script that gathers the otel version. The way that the tag is saved in GitHub versus registry are different. We want to ensure that the version saved in the `csm-versions` file matches the tag itself.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Ensure that the otel-collector version matches the tag in the registry.
<img width="429" height="84" alt="image" src="https://github.com/user-attachments/assets/906cca53-dd09-4556-8ad7-5e7bab39800c" />

```
 docker pull ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.130.0
0.130.0: Pulling from open-telemetry/opentelemetry-collector-releases/opentelemetry-collector
a55387ebd0f1: Download complete
4590f53f2bec: Download complete
9f7dfbcd1a86: Download complete
Digest: sha256:0c066d4388070dad8dc9961d9f23649e85a226620e6b359334e4a6c7f9d73b23
Status: Downloaded newer image for ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.130.0
ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.130.0
```